### PR TITLE
do not specify a compute image id.

### DIFF
--- a/config/develop/veoibd.yaml
+++ b/config/develop/veoibd.yaml
@@ -2,7 +2,6 @@
 template_path: veoibd.yaml
 stack_name: veoibd
 parameters:
-  ComputeImageId: ami-082278746f893d99c
   MainContainer: sagebionetworks/veoibd-validation-docker:latest
   Department: "SysBio"
   Project: "veoibd"

--- a/config/prod/veoibd.yaml
+++ b/config/prod/veoibd.yaml
@@ -2,7 +2,6 @@
 template_path: veoibd.yaml
 stack_name: veoibd
 parameters:
-  ComputeImageId: ami-082278746f893d99c
   MainContainer: sagebionetworks/veoibd-validation-docker:latest
   Department: "SysBio"
   Project: "veoibd"

--- a/templates/veoibd.yaml
+++ b/templates/veoibd.yaml
@@ -8,9 +8,6 @@ Parameters:
     Description: The name of the VPC to use for this Batch environment.
     Type: String
     AllowedValues: ["computevpc", "sandcastlevpc"]
-  ComputeImageId:
-    Description: The Genie compute resource image ID
-    Type: 'AWS::EC2::Image::Id'
   MainContainer:
     Description: The Genie main processing and validation docker container image
     Type: String
@@ -105,7 +102,6 @@ Resources:
           - Fn::ImportValue:
               !Sub '${AWS::Region}-${VpcName}-PrivateSubnet2'
         MinvCpus: 0
-        ImageId: !Ref ComputeImageId
         InstanceRole: !GetAtt BatchInstanceProfile.Arn
         InstanceTypes:
           - optimal


### PR DESCRIPTION
Use the default ecs-optimized image.